### PR TITLE
Add different part for dockerized version

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,7 +4,7 @@ German language files for Freeswitch. Conference sound files only -primarily for
 
 To do so, replace files in /opt/freeswitch/share/freeswitch/sounds/en/us/callie/conference
 
-If you use the docker version from [alangecker/bigbluebutton-docker](https://github.com/alangecker/bigbluebutton-docker) you simply add a volume mapping to the following path inside your container:
+If you use the docker version from [alangecker/bigbluebutton-docker](https://github.com/alangecker/bigbluebutton-docker) simply add a volume mapping to the following path inside your container:
 ```
 /usr/share/freeswitch/sounds/en/us/callie/conference
 ```

--- a/README.md
+++ b/README.md
@@ -4,4 +4,9 @@ German language files for Freeswitch. Conference sound files only -primarily for
 
 To do so, replace files in /opt/freeswitch/share/freeswitch/sounds/en/us/callie/conference
 
+If you use the docker version from [alangecker/bigbluebutton-docker](https://github.com/alangecker/bigbluebutton-docker) you simply add a volume mapping to the following path inside your container:
+```
+/usr/share/freeswitch/sounds/en/us/callie/conference
+```
+
 I'm always open for other/better translation suggestions!


### PR DESCRIPTION
The dockerized version installs freeswitch to a different location. In that case the volume mapping must point to a different path.